### PR TITLE
Fix normals (real)

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,7 +145,7 @@
         <a
           href="https://github.com/Murugo/Misc-Game-Research/tree/main/PS2/Silent%20Hill%202%2B3/Blender/addons/io_sh2_sh3">blender
           addon</a>
-        for both ps2 and pc models! he helped me fix the normals as of v0.1.8. also, murugo has
+        for both ps2 and pc models! he helped me fix the normals as of v0.1.10. also, murugo has
         reversed the blendshape data in models, as well as the animation and shadow formats!
       </li>
       <li>
@@ -214,8 +214,9 @@
         this gives the most accurate skeletons.
       </li>
       <li>
-        in material settings, be sure to set the blending mode to "alpha clip".
-        this will help textures render correctly.
+        in material settings, be sure to set the blend mode for any transparent parts
+        (including hair) to "alpha hashed". all non-transparent parts should be set to
+        "alpha clip".
       </li>
       <li class="no-margin-bottom">
         hide the armature if you don't want to see the bones.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "silent-hill-museum",
-  "version": "0.0.5",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "silent-hill-museum",
-      "version": "0.0.5",
+      "version": "0.1.10",
       "hasInstallScript": true,
       "dependencies": {
         "decode-dxt": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "silent-hill-museum",
   "description": "Explore Silent Hill models",
   "author": "Laura Ann",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/style.css
+++ b/public/style.css
@@ -126,7 +126,7 @@ button:hover {
   width: 75%;
   max-height: 75%;
   transform: translate(-50%, -50%);
-  overflow-y: scroll;
+  overflow-y: auto;
   background-color: rgba(0, 0, 0);
   border: 1px solid #aaa;
   padding: 1rem;

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,6 +39,7 @@ import {
 import {
   OrbitControls,
   TransformControls,
+  VertexNormalsHelper,
   WebGL,
 } from "three/examples/jsm/Addons.js";
 import {
@@ -162,6 +163,7 @@ if (clientState.getGlVersion() === 2) {
   controlsGuiFolder.hide();
   geometryFolder.add(clientState.params, "Auto-Rotate");
 }
+geometryFolder.add(clientState.params, "Visualize Normals");
 geometryFolder.onFinishChange(() => render());
 
 const textureFolder = gui.addFolder("Texture");
@@ -368,7 +370,6 @@ const render = () => {
     let modelSkeleton: Skeleton | undefined = undefined;
     if (primaryGeometry) {
       primaryGeometry.name = `${clientState.file}-primary`;
-      primaryGeometry.computeVertexNormals();
 
       let mesh: Mesh;
 
@@ -392,6 +393,11 @@ const render = () => {
       }
       mesh.renderOrder = 1;
 
+      if (clientState.params["Visualize Normals"]) {
+        const normalsHelper = new VertexNormalsHelper(mesh, 8, 0xff0000);
+        scene.add(normalsHelper);
+      }
+
       console.log("Added primary geometry to mesh!", primaryGeometry);
       group.add(mesh);
     }
@@ -400,7 +406,6 @@ const render = () => {
       ? createGeometry(model, 1)
       : undefined;
     if (secondaryGeometry) {
-      secondaryGeometry.computeVertexNormals();
       secondaryGeometry.name = `${clientState.file}-secondary`;
 
       let mesh: SkinnedMesh | Mesh;

--- a/src/model.ts
+++ b/src/model.ts
@@ -161,11 +161,9 @@ const processPrimitiveHeaders = (
   const normals: number[] = [];
   geometryData.vertexList.forEach((vertex, vertexIndex) => {
     const positionVector = new Vector3(vertex.x, vertex.y, vertex.z);
-    const normalVector = new Vector3(
-      vertex.normals[0],
-      vertex.normals[1],
-      vertex.normals[2]
-    ).divideScalar(MIN_SIGNED_INT);
+    const normalVector = new Vector3(...vertex.normals).divideScalar(
+      MIN_SIGNED_INT
+    );
     let primitiveIndex = 0;
     for (; primitiveIndex < primitiveVertexSets.length; primitiveIndex++) {
       if (primitiveVertexSets[primitiveIndex].has(vertexIndex)) {

--- a/src/objects/MuseumState.ts
+++ b/src/objects/MuseumState.ts
@@ -169,6 +169,7 @@ export default class MuseumState {
     "Render Extra": true,
     "Skeleton Mode": this.glVersion === 2,
     "Visualize Skeleton": false,
+    "Visualize Normals": false,
 
     "Render Mode": MaterialView.Textured as string,
     "Ambient Color": 0xffffff,


### PR DESCRIPTION
Test this branch at the staging URL: https://silenthillmuseum.org/staging/

This is the same change attempted in v0.1.8, except there I forgot to extract each rotation matrix before inverse/transposing and applying to the normals.

@Raq1 I'm sorry for the hasty ping last night, I should be holding my main branch to a higher standard. So here's a more careful PR that I've bug-tested!
Also, I agree with you about the hair needing to use the alpha hashed blending mode! I've added that to the Blender instructions. I've learned from Murugo that PS2 games often use two sections of primitives, one that should be used with alpha clip and the other with alpha blending, so SH2 is no anomaly here.

&nbsp;&nbsp;&nbsp;&nbsp;🟣&nbsp;&nbsp;Original vertex normals restored.
&nbsp;&nbsp;&nbsp;&nbsp;🟣&nbsp;&nbsp;Simplified and revised Blender import instructions.
&nbsp;&nbsp;&nbsp;&nbsp;🟣&nbsp;&nbsp;Added a "Visualize Normals" option to the controls.

<img width="239" alt="Angela, with lighting" src="https://github.com/user-attachments/assets/fb44dab4-be8d-43a3-9087-55a53d882bc0">
<img width="239" alt="Angela, solid viewport shading" src="https://github.com/user-attachments/assets/d6b2222e-0de6-451b-a065-fdaab96a8ffc">
<br>
<img width="239" alt="Laura, with lighting" src="https://github.com/user-attachments/assets/9fd85f5d-b12b-4960-be4c-f31ee2d79149">
<img width="239" alt="Laura, solid viewport shading" src="https://github.com/user-attachments/assets/cdc84d47-5657-4819-8b8f-f172e80e67a9">

Let me know what you think, hopefully all checks out!