### PR TITLE
editor fix: incorrect bone pairs cause broken textures for b_d05.mdl

### DIFF
--- a/src/objects/SerializableModel.ts
+++ b/src/objects/SerializableModel.ts
@@ -832,11 +832,7 @@ export default class SerializableModel {
         for (let pairIndex = 1; pairIndex <= 3; pairIndex++) {
           const parent = targetBone;
           let child = bonemap[boneIndices[skinIndex + pairIndex]];
-          if (
-            parent === undefined ||
-            child === undefined ||
-            child === targetBone
-          ) {
+          if (parent === undefined || child === undefined || parent >= child) {
             continue;
           }
           const mapKey = (parent << 8) | child;


### PR DESCRIPTION
in some cases, edit mode will insert a bone pair even if it is unnecessary or incorrect.

most mdl files don't have any bytes in the `bone_pairs` or `default_pcms_matrices` fields. for example, [`b_d05.mdl`](https://silenthillmuseum.org/?model=chr-item-b_d05), which has a disjoint skeleton, normally has no bone pairs, but exporting an edit with the "by name" bonemap method produces an output containing one bone pair. this change prevents this by ensuring that the bone pair is well-formed before trying to use it