### PR TITLE
sh1: ps1-style texture rendering + more characters

### DIFF
--- a/ksy/ilm.ksy
+++ b/ksy/ilm.ksy
@@ -123,12 +123,14 @@ types:
       - id: uv0
         type: uv
 
-      - type: s2
+      - id: clut_index
+        type: clut_index
 
       - id: uv1
         type: uv
 
-      - type: s2
+      - id: tpage_info
+        type: s2
 
       - id: uv2
         type: uv
@@ -157,3 +159,21 @@ types:
         type: u1
       - id: v3
         type: u1
+
+  xy_pair:
+    seq:
+      - id: x
+        type: s2
+      - id: y
+        type: s2
+
+  clut_index:
+    seq:
+      - id: value
+        type: s2
+
+    instances:
+      x:
+        value: (value & 0x3f) * 0x10
+      y:
+        value: (value >> 6) & 0x1FF

--- a/ksy/psx_tim.ksy
+++ b/ksy/psx_tim.ksy
@@ -1,0 +1,52 @@
+meta:
+  id: psx_tim
+  application: Sony PlayStation (PSX) typical image format
+  file-extension: tim
+  xref:
+    justsolve: TIM_(PlayStation_graphics)
+    wikidata: Q28207389
+  license: CC0-1.0
+  ks-version: 0.9
+  endian: le
+doc-ref:
+  - http://fileformats.archiveteam.org/wiki/TIM_(PlayStation_graphics)
+  - https://mrclick.zophar.net/TilEd/download/timgfx.txt
+  - https://www.romhacking.net/documents/31/
+seq:
+  - id: magic
+    contents: [0x10, 0, 0, 0]
+  - id: flags
+    type: u4
+    doc: Encodes bits-per-pixel and whether CLUT is present in a file or not
+  - id: clut
+    type: bitmap
+    if: has_clut
+    doc: CLUT (Color LookUp Table), one or several palettes for indexed color image, represented as a
+  - id: img
+    type: bitmap
+types:
+  bitmap:
+    seq:
+      - id: len
+        type: u4
+      - id: origin_x
+        type: u2
+      - id: origin_y
+        type: u2
+      - id: width
+        type: u2
+      - id: height
+        type: u2
+      - id: body
+        size: len - 12 # 4 + 4 * 2
+instances:
+  has_clut:
+    value: flags & 0b1000 != 0
+  bpp:
+    value: flags & 0b0011
+enums:
+  bpp_type:
+    0: bpp_4
+    1: bpp_8
+    2: bpp_16
+    3: bpp_24

--- a/ksy/sh1anm.ksy
+++ b/ksy/sh1anm.ksy
@@ -17,14 +17,16 @@ seq:
   - id: magic
     type: s2
 
-  - id: num_rotation_bones
+  - id: num_rotations
     type: u1
 
-  - id: num_translation_bones
+  - id: num_translations
     type: u1
 
   - id: frame_size
     type: s2
+    valid:
+      eq: num_rotations * 9 + num_translations * 3
 
   - id: num_bones
     type: s2
@@ -44,35 +46,48 @@ seq:
 
   - type: u1
 
-  - id: bind_poses
-    type: bind_pose
+  - id: bones
+    type: bone
     repeat: expr
     repeat-expr: num_bones
 
 instances:
-  frame_data:
-    type:
-      switch-on: _index % bones_per_frame >= num_translation_bones
-      cases:
-        true: rotation
-        false: translation
+  frames:
+    type: frame(_index)
     pos: magic
     repeat: expr
-    repeat-expr: num_frames * bones_per_frame
+    repeat-expr: num_frames
 
-  bones_per_frame:
-    value: num_rotation_bones + num_translation_bones
+  transforms_per_frame:
+    value: num_rotations + num_translations
 
 types:
-  bind_pose:
+  frame:
+    params:
+      - id: frame_index
+        type: u2
     seq:
-      - id: bone
-        type: u1
+      - id: translations
+        type: translation
+        repeat: expr
+        repeat-expr: _root.num_translations
+      - id: rotations
+        type: rotation
+        repeat: expr
+        repeat-expr: _root.num_rotations
 
-      - type: u1
-      - type: u1
+  bone:
+    seq:
+      - id: parent
+        type: s1
 
-      - id: translation
+      - id: rotation_index
+        type: s1
+
+      - id: translation_index
+        type: s1
+
+      - id: bind_translation
         type: translation
 
   translation:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "silent-hill-museum",
   "description": "Explore Silent Hill models",
   "author": "Laura Ann",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/glsl/psx_frag.glsl
+++ b/src/glsl/psx_frag.glsl
@@ -1,0 +1,18 @@
+precision mediump float;
+precision mediump int;
+in vec4 vUv;
+
+uniform sampler2D tClutTexture;
+uniform sampler2D imgTexture;
+
+layout(location = 0) out highp vec4 pc_fragColor;
+
+void main() {
+    vec2 img_xy = vec2(vUv.x, vUv.y);
+    float palette_idx = texture(imgTexture, img_xy).r;
+
+    vec2 clut_xy = vec2(palette_idx * 255.0 / 16.0, vUv.w);
+    vec4 j = texture(tClutTexture, clut_xy);
+
+    pc_fragColor = j;
+}

--- a/src/glsl/psx_frag.glsl
+++ b/src/glsl/psx_frag.glsl
@@ -1,7 +1,7 @@
 precision mediump float;
 precision mediump int;
-in vec4 vUv;
 
+in vec4 vUv;
 uniform sampler2D tClutTexture;
 uniform sampler2D imgTexture;
 

--- a/src/glsl/psx_vert.glsl
+++ b/src/glsl/psx_vert.glsl
@@ -1,0 +1,49 @@
+precision mediump float;
+precision mediump int;
+
+uniform mat4 modelViewMatrix;
+uniform mat4 projectionMatrix;
+
+in vec3 position;
+in vec4 uv;
+// attribute vec4 color;
+
+// varying vec3 vPosition;
+// varying vec4 vColor;
+out vec4 vUv;
+
+uniform mat4 bindMatrix;
+uniform mat4 bindMatrixInverse;
+
+in vec4 skinIndex;
+in vec4 skinWeight;
+
+uniform highp sampler2D boneTexture;
+
+mat4 getBoneMatrix(const in float i) {
+
+    int size = textureSize(boneTexture, 0).x;
+    int j = int(i) * 4;
+    int x = j % size;
+    int y = j / size;
+    vec4 v1 = texelFetch(boneTexture, ivec2(x, y), 0);
+    vec4 v2 = texelFetch(boneTexture, ivec2(x + 1, y), 0);
+    vec4 v3 = texelFetch(boneTexture, ivec2(x + 2, y), 0);
+    vec4 v4 = texelFetch(boneTexture, ivec2(x + 3, y), 0);
+
+    return mat4(v1, v2, v3, v4);
+
+}
+
+void main() {
+    vUv = uv;
+
+    vec3 transformed = vec3(position);
+    mat4 boneMatX = getBoneMatrix(skinIndex.x);
+    vec4 skinVertex = bindMatrix * vec4(transformed, 1.0);
+    vec4 skinned = boneMatX * skinVertex * skinWeight.x;
+    transformed = (bindMatrixInverse * skinned).xyz;
+
+    gl_Position = (projectionMatrix * modelViewMatrix * vec4(transformed, 1.0));
+
+}

--- a/src/glsl/psx_vert.glsl
+++ b/src/glsl/psx_vert.glsl
@@ -1,27 +1,20 @@
 precision mediump float;
 precision mediump int;
 
-uniform mat4 modelViewMatrix;
-uniform mat4 projectionMatrix;
-
 in vec3 position;
 in vec4 uv;
-// attribute vec4 color;
-
-// varying vec3 vPosition;
-// varying vec4 vColor;
-out vec4 vUv;
-
-uniform mat4 bindMatrix;
-uniform mat4 bindMatrixInverse;
-
 in vec4 skinIndex;
 in vec4 skinWeight;
 
+uniform mat4 modelViewMatrix;
+uniform mat4 projectionMatrix;
+uniform mat4 bindMatrix;
+uniform mat4 bindMatrixInverse;
 uniform highp sampler2D boneTexture;
 
-mat4 getBoneMatrix(const in float i) {
+out vec4 vUv;
 
+mat4 getBoneMatrix(const in float i) {
     int size = textureSize(boneTexture, 0).x;
     int j = int(i) * 4;
     int x = j % size;
@@ -30,9 +23,7 @@ mat4 getBoneMatrix(const in float i) {
     vec4 v2 = texelFetch(boneTexture, ivec2(x + 1, y), 0);
     vec4 v3 = texelFetch(boneTexture, ivec2(x + 2, y), 0);
     vec4 v4 = texelFetch(boneTexture, ivec2(x + 3, y), 0);
-
     return mat4(v1, v2, v3, v4);
-
 }
 
 void main() {
@@ -45,5 +36,4 @@ void main() {
     transformed = (bindMatrixInverse * skinned).xyz;
 
     gl_Position = (projectionMatrix * modelViewMatrix * vec4(transformed, 1.0));
-
 }

--- a/src/kaitai/Ilm.d.ts
+++ b/src/kaitai/Ilm.d.ts
@@ -27,15 +27,27 @@ declare class Ilm {
 }
 
 declare namespace Ilm {
+  class ClutIndex {
+    constructor(io: any, parent?: any, root?: any);
+    __type: "ClutIndex";
+    _io: any;
+
+    x: number;
+    y: number;
+    value: number;
+  }
+}
+
+declare namespace Ilm {
   class IndexPacket {
     constructor(io: any, parent?: any, root?: any);
     __type: "IndexPacket";
     _io: any;
 
     uv0: Ilm.Uv;
-    _unnamed1: number;
+    clutIndex: Ilm.ClutIndex;
     uv1: Ilm.Uv;
-    _unnamed3: number;
+    tpageInfo: number;
     uv2: Ilm.Uv;
     uv3: Ilm.Uv;
     indices: Ilm.PrimIndices;

--- a/src/kaitai/Ilm.js
+++ b/src/kaitai/Ilm.js
@@ -174,6 +174,35 @@ var Ilm = (function () {
     return Obj;
   })());
 
+  var ClutIndex = (Ilm.ClutIndex = (function () {
+    function ClutIndex(_io, _parent, _root) {
+      this._io = _io;
+      this._parent = _parent;
+      this._root = _root || this;
+
+      this._read();
+    }
+    ClutIndex.prototype._read = function () {
+      this.value = this._io.readS2le();
+    };
+    Object.defineProperty(ClutIndex.prototype, "x", {
+      get: function () {
+        if (this._m_x !== undefined) return this._m_x;
+        this._m_x = (this.value & 63) * 16;
+        return this._m_x;
+      },
+    });
+    Object.defineProperty(ClutIndex.prototype, "y", {
+      get: function () {
+        if (this._m_y !== undefined) return this._m_y;
+        this._m_y = (this.value >>> 6) & 511;
+        return this._m_y;
+      },
+    });
+
+    return ClutIndex;
+  })());
+
   var IndexPacket = (Ilm.IndexPacket = (function () {
     function IndexPacket(_io, _parent, _root) {
       this._io = _io;
@@ -184,9 +213,9 @@ var Ilm = (function () {
     }
     IndexPacket.prototype._read = function () {
       this.uv0 = new Uv(this._io, this, this._root);
-      this._unnamed1 = this._io.readS2le();
+      this.clutIndex = new ClutIndex(this._io, this, this._root);
       this.uv1 = new Uv(this._io, this, this._root);
-      this._unnamed3 = this._io.readS2le();
+      this.tpageInfo = this._io.readS2le();
       this.uv2 = new Uv(this._io, this, this._root);
       this.uv3 = new Uv(this._io, this, this._root);
       this.indices = new PrimIndices(this._io, this, this._root);
@@ -212,6 +241,22 @@ var Ilm = (function () {
     };
 
     return PrimIndices;
+  })());
+
+  var XyPair = (Ilm.XyPair = (function () {
+    function XyPair(_io, _parent, _root) {
+      this._io = _io;
+      this._parent = _parent;
+      this._root = _root || this;
+
+      this._read();
+    }
+    XyPair.prototype._read = function () {
+      this.x = this._io.readS2le();
+      this.y = this._io.readS2le();
+    };
+
+    return XyPair;
   })());
   Object.defineProperty(Ilm.prototype, "idTable", {
     get: function () {

--- a/src/kaitai/PsxTim.d.ts
+++ b/src/kaitai/PsxTim.d.ts
@@ -1,0 +1,54 @@
+// This is a generated file! Please edit source .ksy file and use kaitai-struct-compiler to rebuild
+
+/**
+ * @see {@link http://fileformats.archiveteam.org/wiki/TIM_(PlayStation_graphics)|Source}
+ * @see {@link https://mrclick.zophar.net/TilEd/download/timgfx.txt|Source}
+ * @see {@link https://www.romhacking.net/documents/31/|Source}
+ */
+declare class PsxTim {
+  constructor(io: any, parent?: any, root?: any);
+  __type: "PsxTim";
+  _io: any;
+
+  bpp: number;
+  hasClut: boolean;
+  magic: Uint8Array;
+
+  /**
+   * Encodes bits-per-pixel and whether CLUT is present in a file or not
+   */
+  flags: number;
+
+  /**
+   * CLUT (Color LookUp Table), one or several palettes for indexed color image, represented as a
+   */
+  clut: PsxTim.Bitmap;
+  img: PsxTim.Bitmap;
+}
+
+declare namespace PsxTim {
+  class Bitmap {
+    constructor(io: any, parent?: any, root?: any);
+    __type: "Bitmap";
+    _io: any;
+
+    len: number;
+    originX: number;
+    originY: number;
+    width: number;
+    height: number;
+    body: Uint8Array;
+  }
+}
+
+declare namespace PsxTim {
+  enum BppType {
+    BPP_4 = 0,
+    BPP_8 = 1,
+    BPP_16 = 2,
+    BPP_24 = 3,
+  }
+}
+
+export = PsxTim;
+export as namespace PsxTim;

--- a/src/kaitai/PsxTim.js
+++ b/src/kaitai/PsxTim.js
@@ -1,0 +1,93 @@
+// This is a generated file! Please edit source .ksy file and use kaitai-struct-compiler to rebuild
+
+import KaitaiStream from "./runtime/KaitaiStream";
+
+/**
+ * @see {@link http://fileformats.archiveteam.org/wiki/TIM_(PlayStation_graphics)|Source}
+ * @see {@link https://mrclick.zophar.net/TilEd/download/timgfx.txt|Source}
+ * @see {@link https://www.romhacking.net/documents/31/|Source}
+ */
+
+var PsxTim = (function () {
+  PsxTim.BppType = Object.freeze({
+    BPP_4: 0,
+    BPP_8: 1,
+    BPP_16: 2,
+    BPP_24: 3,
+
+    0: "BPP_4",
+    1: "BPP_8",
+    2: "BPP_16",
+    3: "BPP_24",
+  });
+
+  function PsxTim(_io, _parent, _root) {
+    this._io = _io;
+    this._parent = _parent;
+    this._root = _root || this;
+
+    this._read();
+  }
+  PsxTim.prototype._read = function () {
+    this.magic = this._io.readBytes(4);
+    if (!(KaitaiStream.byteArrayCompare(this.magic, [16, 0, 0, 0]) == 0)) {
+      throw new KaitaiStream.ValidationNotEqualError(
+        [16, 0, 0, 0],
+        this.magic,
+        this._io,
+        "/seq/0"
+      );
+    }
+    this.flags = this._io.readU4le();
+    if (this.hasClut) {
+      this.clut = new Bitmap(this._io, this, this._root);
+    }
+    this.img = new Bitmap(this._io, this, this._root);
+  };
+
+  var Bitmap = (PsxTim.Bitmap = (function () {
+    function Bitmap(_io, _parent, _root) {
+      this._io = _io;
+      this._parent = _parent;
+      this._root = _root || this;
+
+      this._read();
+    }
+    Bitmap.prototype._read = function () {
+      this.len = this._io.readU4le();
+      this.originX = this._io.readU2le();
+      this.originY = this._io.readU2le();
+      this.width = this._io.readU2le();
+      this.height = this._io.readU2le();
+      this.body = this._io.readBytes(this.len - 12);
+    };
+
+    return Bitmap;
+  })());
+  Object.defineProperty(PsxTim.prototype, "hasClut", {
+    get: function () {
+      if (this._m_hasClut !== undefined) return this._m_hasClut;
+      this._m_hasClut = (this.flags & 8) != 0;
+      return this._m_hasClut;
+    },
+  });
+  Object.defineProperty(PsxTim.prototype, "bpp", {
+    get: function () {
+      if (this._m_bpp !== undefined) return this._m_bpp;
+      this._m_bpp = this.flags & 3;
+      return this._m_bpp;
+    },
+  });
+
+  /**
+   * Encodes bits-per-pixel and whether CLUT is present in a file or not
+   */
+
+  /**
+   * CLUT (Color LookUp Table), one or several palettes for indexed color image, represented as a
+   */
+
+  return PsxTim;
+})();
+
+export default PsxTim;

--- a/src/kaitai/Sh1anm.d.ts
+++ b/src/kaitai/Sh1anm.d.ts
@@ -14,13 +14,12 @@ declare class Sh1anm {
   constructor(io: any, parent?: any, root?: any);
   __type: "Sh1anm";
   _io: any;
-  _m_frameData: Array<Sh1anm.Translation | Sh1anm.Rotation> | undefined;
 
-  bonesPerFrame: number;
-  frameData: Array<Sh1anm.Translation | Sh1anm.Rotation>;
+  frames: Sh1anm.Frame[];
+  transformsPerFrame: number;
   magic: number;
-  numRotationBones: number;
-  numTranslationBones: number;
+  numRotations: number;
+  numTranslations: number;
   frameSize: number;
   numBones: number;
   flags: number;
@@ -32,19 +31,31 @@ declare class Sh1anm {
    */
   scaleLog2: number;
   _unnamed9: number;
-  bindPoses: Sh1anm.BindPose[];
+  bones: Sh1anm.Bone[];
 }
 
 declare namespace Sh1anm {
-  class BindPose {
+  class Bone {
     constructor(io: any, parent?: any, root?: any);
-    __type: "BindPose";
+    __type: "Bone";
     _io: any;
 
-    bone: number;
-    _unnamed1: number;
-    _unnamed2: number;
-    translation: Sh1anm.Translation;
+    parent: number;
+    rotationIndex: number;
+    translationIndex: number;
+    bindTranslation: Sh1anm.Translation;
+  }
+}
+
+declare namespace Sh1anm {
+  class Frame {
+    constructor(io: any, parent?: any, root?: any);
+    __type: "Frame";
+    _io: any;
+
+    translations: Sh1anm.Translation[];
+    rotations: Sh1anm.Rotation[];
+    frameIndex: number;
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -154,11 +154,7 @@ const gameInput = dataGuiFolder
     render();
   });
 const sh1FileInput = dataGuiFolder
-  .add(
-    clientState.uiParams,
-    "File (SH1)",
-    ilmFiles.map((x) => x.replace(".ILM", ""))
-  )
+  .add(clientState.uiParams, "File (SH1)", ilmFiles)
   .hide()
   .onFinishChange(() => render())
   .listen();
@@ -229,7 +225,10 @@ dataGuiFolder.add(clientState.uiParams, "View Structure 🔎");
 dataGuiFolder.add(clientState.uiParams, "Next File");
 dataGuiFolder.add(clientState.uiParams, "Previous File");
 dataGuiFolder.add(clientState.uiParams, "Save Image");
-dataGuiFolder.add(clientState.uiParams, "Export to GLTF");
+const exportToGltfButton = dataGuiFolder.add(
+  clientState.uiParams,
+  "Export to GLTF"
+);
 fileInput.onFinishChange((file: (typeof possibleFilenames)[number]) => {
   clientState.file = file;
 });
@@ -922,11 +921,14 @@ const renderSh1 = async () => {
     clientState.uiParams["Render Mode"] === MaterialView.Textured
       ? shaderMaterial
       : new MeshStandardMaterial({
-          map: (() => {
-            const t = new DataTexture(defaultDiffuseMap, 128, 128);
-            t.needsUpdate = true;
-            return t;
-          })(),
+          map:
+            clientState.uiParams["Render Mode"] === MaterialView.UV
+              ? (() => {
+                  const t = new DataTexture(defaultDiffuseMap, 128, 128);
+                  t.needsUpdate = true;
+                  return t;
+                })()
+              : undefined,
           wireframe:
             clientState.uiParams["Render Mode"] === MaterialView.Wireframe,
           alphaTest: clientState.uiParams["Alpha Test"],
@@ -1297,6 +1299,9 @@ const render = () => {
     textureViewerButton.show();
     invertAlphaInput.hide();
 
+    exportToGltfButton.name("[export temporarily unavailable]");
+    exportToGltfButton.disable();
+
     if (clientState.getGlVersion() === 1) {
       showQuickModal(
         "<p>WebGL 2 is required for Silent Hill 1 models for now.</p>" +
@@ -1317,6 +1322,9 @@ const render = () => {
     skeletonModeController?.show();
     editModeButton.show();
     invertAlphaInput.show();
+
+    exportToGltfButton.name("Export to GLTF");
+    exportToGltfButton.enable();
   }
 
   const filename = isSh2
@@ -1332,7 +1340,7 @@ const render = () => {
     lastGame = clientState.uiParams.Game;
 
     if (
-      ((isSh1 && lastSh1File !== "HERO") ||
+      ((isSh1 && lastSh1File !== "MTH") ||
         clientState.folder !== "favorites") &&
       !clientState.hasAcceptedContentWarning()
     ) {

--- a/src/objects/MuseumState.ts
+++ b/src/objects/MuseumState.ts
@@ -463,7 +463,7 @@ export default class MuseumState {
 
   public uiParams = {
     Game: Math.random() > 0.5 ? "Silent Hill 1" : "Silent Hill 2",
-    "File (SH1)": "DARIA" as (typeof ilmFiles)[number],
+    "File (SH1)": "MTH" as (typeof ilmFiles)[number],
     Scenario: this.rootFolder === "chr" ? "Main Scenario" : "Born From A Wish",
     Folder: this.folder,
     Filename: this.file,
@@ -605,25 +605,6 @@ export const defaultParams = Object.assign(
     )
   )
 );
-
-export const sh1Files = [
-  "AR",
-  "BAR",
-  "BLISA",
-  "BOS",
-  "BTFY",
-  "CAT",
-  "CKN",
-  "DARIA",
-  "FRG",
-  "HERO",
-  "KAU",
-  "LISA",
-  "MAR",
-  "SIBYL",
-  "SRL",
-  "WRM",
-].sort();
 
 export type MuseumMixer = AnimationMixer & {
   _actions: AnimationAction[];

--- a/src/objects/MuseumState.ts
+++ b/src/objects/MuseumState.ts
@@ -30,6 +30,7 @@ import { renderStructToContainer } from "../visualize-struct";
 import { anmToMdlAssoc } from "../animation";
 import anmList from "../assets/anm-list.json";
 import Ilm from "../kaitai/Ilm";
+import { ilmFiles } from "../sh1";
 
 export const START_INDEX = constructIndex("chr", "favorites", "inu.mdl");
 const START_PATH_ARRAY = destructureIndex(START_INDEX);
@@ -51,7 +52,8 @@ export default class MuseumState {
 
     if (game === "sh1") {
       this.uiParams["Game"] = "Silent Hill 1";
-      this.uiParams["File (SH1)"] = params.get("file") ?? "DARIA";
+      this.uiParams["File (SH1)"] =
+        (params.get("file") as (typeof ilmFiles)[number]) ?? "HERO";
       return;
     }
 
@@ -148,8 +150,8 @@ export default class MuseumState {
   public nextFile() {
     if (this.uiParams["Game"] === "Silent Hill 1") {
       this.uiParams["File (SH1)"] =
-        sh1Files[
-          (sh1Files.indexOf(this.uiParams["File (SH1)"]) + 1) % sh1Files.length
+        ilmFiles[
+          (ilmFiles.indexOf(this.uiParams["File (SH1)"]) + 1) % ilmFiles.length
         ];
       this.onUpdate();
       return;
@@ -167,11 +169,11 @@ export default class MuseumState {
   public previousFile() {
     if (this.uiParams["Game"] === "Silent Hill 1") {
       this.uiParams["File (SH1)"] =
-        sh1Files[
-          (sh1Files.indexOf(this.uiParams["File (SH1)"]) -
+        ilmFiles[
+          (ilmFiles.indexOf(this.uiParams["File (SH1)"]) -
             1 +
-            sh1Files.length) %
-            sh1Files.length
+            ilmFiles.length) %
+            ilmFiles.length
         ];
       this.onUpdate();
       return;
@@ -461,7 +463,7 @@ export default class MuseumState {
 
   public uiParams = {
     Game: Math.random() > 0.5 ? "Silent Hill 1" : "Silent Hill 2",
-    "File (SH1)": "DARIA",
+    "File (SH1)": "DARIA" as (typeof ilmFiles)[number],
     Scenario: this.rootFolder === "chr" ? "Main Scenario" : "Born From A Wish",
     Folder: this.folder,
     Filename: this.file,
@@ -605,13 +607,22 @@ export const defaultParams = Object.assign(
 );
 
 export const sh1Files = [
-  "SRL",
   "AR",
-  "LISA",
+  "BAR",
   "BLISA",
+  "BOS",
+  "BTFY",
+  "CAT",
+  "CKN",
   "DARIA",
-  "SIBYL",
+  "FRG",
+  "HERO",
   "KAU",
+  "LISA",
+  "MAR",
+  "SIBYL",
+  "SRL",
+  "WRM",
 ].sort();
 
 export type MuseumMixer = AnimationMixer & {

--- a/src/sh1.ts
+++ b/src/sh1.ts
@@ -439,7 +439,6 @@ export const texture = (psxTim: PsxTim, bpp = 4) => {
 
 // 🗂️ ------- file structure associations ------- 🗂️
 export const ilmToAnmArray = [
-  ["HERO", "HR"],
   ["BOS", "BOS"],
   ["BOS2", "BOS"],
   ["TDRA", "TDA"],
@@ -459,6 +458,7 @@ export const ilmToAnmArray = [
   ["KAU", "KAU"],
   ["SIBYL", "SBL2"],
   ["HERO", "HR_E01"],
+  ["HERO", "HR"],
   ["SIBYL", "SBL_LAST"],
   // ["SNK", "SPD"],
 ] as const;
@@ -509,8 +509,8 @@ export const ilmFiles = [
   "AR",
   "BAR",
   "BD2",
-  "BFLU",
-  "BIG",
+  // "BFLU",
+  // "BIG",
   "BIRD",
   "BLISA",
   "BOS",
@@ -537,7 +537,7 @@ export const ilmFiles = [
   "KAU",
   "LISA",
   "LITL",
-  "MAN",
+  // "MAN",
   "MAR",
   "MKY",
   "MSB",

--- a/src/sh1.ts
+++ b/src/sh1.ts
@@ -378,7 +378,7 @@ export const texture = (psxTim: PsxTim, bpp = 4) => {
     clutTexture[clutIndex] = r;
     clutTexture[clutIndex + 1] = g;
     clutTexture[clutIndex + 2] = b;
-    clutTexture[clutIndex + 3] = 255;
+    clutTexture[clutIndex + 3] = clut16 === 0 ? 0 : 255;
 
     clutIndex += 4;
   }

--- a/src/sh1.ts
+++ b/src/sh1.ts
@@ -4,13 +4,17 @@
 import {
   Bone,
   BufferGeometry,
+  DataTexture,
   Float32BufferAttribute,
+  GLSL3,
   InterpolateLinear,
   KeyframeTrack,
   Matrix3,
   Matrix4,
   Quaternion,
   QuaternionKeyframeTrack,
+  RawShaderMaterial,
+  RedFormat,
   Skeleton,
   Uint16BufferAttribute,
   Vector3,
@@ -22,13 +26,21 @@ import Sh1anm from "./kaitai/Sh1anm";
 import { Tuple } from "./types/common";
 import { BufferGeometryUtils } from "three/examples/jsm/Addons.js";
 import { ANIMATION_FRAME_DURATION } from "./utils";
+import PsxTim from "./kaitai/PsxTim";
 
 // I mostly just want to quickly create a prototype for sh1 support before
 // making any big structural changes to the code
 
 // 🔺 ------- model building ------- 🔺
 
-export const createSh1Geometry = (ilm: Ilm, skeleton: Skeleton) => {
+type GeometryInit = {
+  ilm: Ilm;
+  skeleton: Skeleton;
+  psxTim: PsxTim;
+};
+
+export const createSh1Geometry = (init: GeometryInit) => {
+  const { ilm, skeleton, psxTim } = init;
   let geom = new BufferGeometry();
   const bones = skeleton.bones;
   for (const bone of bones) {
@@ -37,7 +49,6 @@ export const createSh1Geometry = (ilm: Ilm, skeleton: Skeleton) => {
 
   // first pass: collect metadata before making buffers
   let vertexBufferSize = 0;
-  let uvBufferSize = 0;
   let boneBufferSize = 0;
 
   for (let objectIndex = 0; objectIndex < ilm.numObjs; objectIndex++) {
@@ -50,12 +61,10 @@ export const createSh1Geometry = (ilm: Ilm, skeleton: Skeleton) => {
 
       if (isTriangle) {
         vertexBufferSize += 9;
-        uvBufferSize += 6;
         boneBufferSize += 12;
       } else {
         // split quads into two triangles. the PSX GPU does this as well
         vertexBufferSize += 18;
-        uvBufferSize += 12;
         boneBufferSize += 24;
       }
     }
@@ -64,7 +73,7 @@ export const createSh1Geometry = (ilm: Ilm, skeleton: Skeleton) => {
   // second pass: make buffers
   const scratchpadBuffer = new Float32Array(128 * 4);
   const vertexBuffer = new Float32Array(vertexBufferSize);
-  const uvBuffer = new Float32Array(uvBufferSize);
+  const uvBuffer = new Float32Array(boneBufferSize);
   const skinIndexBuffer = new Uint16Array(boneBufferSize);
   const skinWeightBuffer = new Float32Array(skinIndexBuffer);
 
@@ -72,9 +81,15 @@ export const createSh1Geometry = (ilm: Ilm, skeleton: Skeleton) => {
   let uvIndex = 0;
   let skinIndex = 0;
 
-  const u = (x: number) => x / 0xff;
-  const v = (x: number) => 2 * (1.0 - x / 0xff);
-  const loadFromScratchpad = (uv: Ilm.Uv, index: number) => {
+  const u = (x: number) => x / (psxTim.img.width * 4);
+  const v = (x: number) => x / psxTim.img.height;
+
+  const loadFromScratchpad = (
+    clut: Ilm.ClutIndex,
+    tpage: number,
+    uv: Ilm.Uv,
+    index: number
+  ) => {
     vertexBuffer[vertexIndex] = scratchpadBuffer[index];
     vertexBuffer[vertexIndex + 1] = scratchpadBuffer[index + 1];
     vertexBuffer[vertexIndex + 2] = scratchpadBuffer[index + 2];
@@ -82,7 +97,9 @@ export const createSh1Geometry = (ilm: Ilm, skeleton: Skeleton) => {
 
     uvBuffer[uvIndex] = u(uv.u);
     uvBuffer[uvIndex + 1] = v(uv.v);
-    uvIndex += 2;
+    uvBuffer[uvIndex + 2] = (tpage & 0x60) >> 4; //clut.x / psxTim.clut.width;
+    uvBuffer[uvIndex + 3] = clut.y / psxTim.clut.height;
+    uvIndex += 4;
 
     skinIndexBuffer[skinIndex] = scratchpadBuffer[index + 3];
     skinIndexBuffer[skinIndex + 1] = 0;
@@ -124,6 +141,7 @@ export const createSh1Geometry = (ilm: Ilm, skeleton: Skeleton) => {
     // now build non-indexed triangle list and uvs
     for (let primIndex = 0; primIndex < info.numPrims; primIndex++) {
       const prim = info.prims[primIndex];
+      const clutIndex = prim.clutIndex;
 
       const indices = prim.indices;
       let [i0, i1, i2, i3] = [
@@ -133,9 +151,12 @@ export const createSh1Geometry = (ilm: Ilm, skeleton: Skeleton) => {
         indices.v3 * 4,
       ];
 
-      // temporary patch until the active bone indices flag is implemented
+      // temporary patch
       if (
         object.name.includes("RHAND2") ||
+        object.name.includes("RHAND3") ||
+        object.name.includes("RHAND4") ||
+        object.name.includes("LHAND2") ||
         object.name.includes("FLAURO") ||
         object.name.includes("KEY") ||
         object.name.includes("RAGLA")
@@ -149,24 +170,24 @@ export const createSh1Geometry = (ilm: Ilm, skeleton: Skeleton) => {
 
       // 2 -> 1 -> 0
       // ---------- 2 ----------
-      loadFromScratchpad(prim.uv2, i2);
+      loadFromScratchpad(clutIndex, prim.tpageInfo, prim.uv2, i2);
 
       // ---------- 1 ----------
-      loadFromScratchpad(prim.uv1, i1);
+      loadFromScratchpad(clutIndex, prim.tpageInfo, prim.uv1, i1);
 
       // ---------- 0 ----------
-      loadFromScratchpad(prim.uv0, i0);
+      loadFromScratchpad(clutIndex, prim.tpageInfo, prim.uv0, i0);
 
       if (isQuad) {
         // 1 -> 2 -> 3
         // ---------- 1 ----------
-        loadFromScratchpad(prim.uv1, i1);
+        loadFromScratchpad(clutIndex, prim.tpageInfo, prim.uv1, i1);
 
         // ---------- 2 ----------
-        loadFromScratchpad(prim.uv2, i2);
+        loadFromScratchpad(clutIndex, prim.tpageInfo, prim.uv2, i2);
 
         // ---------- 3 ----------
-        loadFromScratchpad(prim.uv3, i3);
+        loadFromScratchpad(clutIndex, prim.tpageInfo, prim.uv3, i3);
       }
     }
   }
@@ -177,7 +198,7 @@ export const createSh1Geometry = (ilm: Ilm, skeleton: Skeleton) => {
     "skinWeight",
     new Float32BufferAttribute(skinWeightBuffer, 4)
   );
-  geom.setAttribute("uv", new Float32BufferAttribute(uvBuffer, 2));
+  geom.setAttribute("uv", new Float32BufferAttribute(uvBuffer, 4));
   geom = BufferGeometryUtils.mergeVertices(geom);
 
   return geom;
@@ -189,33 +210,40 @@ export const createSh1Skeleton = (anm: Sh1anm) => {
   const bones: Array<Bone> = [];
 
   const scale = (x: number) => x * (1 << anm.scaleLog2);
+  const frameInfo = anm.frames[0];
+
   for (let i = 0; i < anm.numBones; i++) {
-    const restPose = anm.bindPoses[i];
-    const parentBoneIndex = restPose.bone;
-
-    // use the first frame as initial matrices
-    const matrix = new Matrix4();
-    const frameInfo = anm.frameData[i];
-
-    let t: Vector3Like;
-    if (frameInfo instanceof Sh1anm.Rotation) {
-      t = restPose.translation;
-
-      smatrix(matrix, frameInfo.value);
-    } else {
-      t = frameInfo;
-    }
-    matrix.setPosition(scale(t.x), scale(t.y), scale(t.z));
+    const boneInfo = anm.bones[i];
 
     const bone = new Bone();
     bone.name = `${i}`;
+
+    // use the first frame as initial matrices
+    const matrix = new Matrix4();
+
+    let t: Vector3Like | undefined = undefined;
+    if (boneInfo.rotationIndex >= 0) {
+      t = boneInfo.bindTranslation;
+
+      smatrix(matrix, frameInfo.rotations[boneInfo.rotationIndex].value);
+    } else {
+      t =
+        frameInfo.translations[boneInfo.translationIndex] ??
+        boneInfo.bindTranslation;
+    }
+    matrix.setPosition(scale(t.x), scale(t.y), scale(t.z));
+
     bone.applyMatrix4(matrix);
 
-    if (parentBoneIndex !== 0xff) {
-      bones[parentBoneIndex].add(bone);
-    }
-
     bones.push(bone);
+  }
+
+  for (let i = 0; i < anm.numBones; i++) {
+    const restPose = anm.bones[i];
+    const parentBoneIndex = restPose.parent;
+    if (parentBoneIndex >= 0) {
+      bones[parentBoneIndex].add(bones[i]);
+    }
   }
 
   return new Skeleton(bones);
@@ -231,46 +259,63 @@ const smatrix = (matrix: Matrix4, qMatrix: number[]) => {
 // 🎬 ------- animation building ------- 🎬
 
 export const createSh1Animation = (anm: Sh1anm) => {
-  const boneCount = anm.bonesPerFrame;
+  const boneCount = anm.numBones;
 
   const scale = (x: number) => x * (1 << anm.scaleLog2);
 
   const timeBuffer = new Float32Array(anm.numFrames);
-  const transformBuffers: Array<Float32Array> = [];
+  const transformBuffers: Array<{
+    translations?: Float32Array;
+    rotations?: Float32Array;
+  }> = [];
 
-  for (let boneIndex = 0; boneIndex < anm.numTranslationBones; boneIndex++) {
-    transformBuffers[boneIndex] = new Float32Array(3 * anm.numFrames);
-  }
-  for (
-    let boneIndex = anm.numTranslationBones;
-    boneIndex < anm.bonesPerFrame;
-    boneIndex++
-  ) {
-    transformBuffers[boneIndex] = new Float32Array(4 * anm.numFrames);
-  }
-
-  for (let i = 0; i < anm.frameData.length; i++) {
-    const transform = anm.frameData[i];
-    const boneIndex = i % boneCount;
-    const frameIndex = Math.floor(i / boneCount);
-
-    if (transform instanceof Sh1anm.Translation) {
-      const buffer = transformBuffers[boneIndex];
-      const bufferIndex = 3 * frameIndex;
-      buffer[bufferIndex] = scale(transform.x);
-      buffer[bufferIndex + 1] = scale(transform.y);
-      buffer[bufferIndex + 2] = scale(transform.z);
-    } else {
-      const quat = new Quaternion().setFromRotationMatrix(
-        smatrix(new Matrix4(), transform.value)
+  for (let boneIndex = 0; boneIndex < anm.numBones; boneIndex++) {
+    const bone = anm.bones[boneIndex];
+    transformBuffers[boneIndex] = {};
+    if (bone.translationIndex >= 0) {
+      transformBuffers[boneIndex].translations = new Float32Array(
+        3 * anm.numFrames
       );
+    }
+    if (bone.rotationIndex >= 0) {
+      transformBuffers[boneIndex].rotations = new Float32Array(
+        4 * anm.numFrames
+      );
+    }
+  }
 
-      const buffer = transformBuffers[boneIndex];
-      const bufferIndex = 4 * frameIndex;
-      buffer[bufferIndex] = quat.x;
-      buffer[bufferIndex + 1] = quat.y;
-      buffer[bufferIndex + 2] = quat.z;
-      buffer[bufferIndex + 3] = quat.w;
+  for (let frameIndex = 0; frameIndex < anm.frames.length; frameIndex++) {
+    const frame = anm.frames[frameIndex];
+
+    for (let boneIndex = 0; boneIndex < boneCount; boneIndex++) {
+      const bone = anm.bones[boneIndex];
+      const translations = transformBuffers[boneIndex].translations;
+      const rotations = transformBuffers[boneIndex].rotations;
+
+      if (translations && (boneIndex === 0 || bone.translationIndex !== 0)) {
+        const transform = frame.translations[bone.translationIndex];
+
+        const buffer = translations;
+        const bufferIndex = 3 * frameIndex;
+        buffer[bufferIndex] = scale(transform.x);
+        buffer[bufferIndex + 1] = scale(transform.y);
+        buffer[bufferIndex + 2] = scale(transform.z);
+      }
+
+      if (rotations) {
+        const transform = frame.rotations[bone.rotationIndex];
+
+        const quat = new Quaternion().setFromRotationMatrix(
+          smatrix(new Matrix4(), transform.value)
+        );
+
+        const buffer = rotations;
+        const bufferIndex = 4 * frameIndex;
+        buffer[bufferIndex] = quat.x;
+        buffer[bufferIndex + 1] = quat.y;
+        buffer[bufferIndex + 2] = quat.z;
+        buffer[bufferIndex + 3] = quat.w;
+      }
     }
   }
   for (let i = 0; i < anm.numFrames; i++) {
@@ -278,32 +323,118 @@ export const createSh1Animation = (anm: Sh1anm) => {
   }
 
   const tracks: Array<KeyframeTrack> = [];
-  for (let boneIndex = 0; boneIndex < anm.numTranslationBones; boneIndex++) {
-    tracks.push(
-      new VectorKeyframeTrack(
-        `sh1model.bones[${boneIndex}].position`,
-        timeBuffer,
-        transformBuffers[boneIndex],
-        InterpolateLinear
-      )
-    );
-  }
-  for (
-    let boneIndex = anm.numTranslationBones;
-    boneIndex < anm.bonesPerFrame;
-    boneIndex++
-  ) {
-    tracks.push(
-      new QuaternionKeyframeTrack(
-        `sh1model.bones[${boneIndex}].quaternion`,
-        timeBuffer,
-        transformBuffers[boneIndex],
-        InterpolateLinear
-      )
-    );
+  for (let boneIndex = 0; boneIndex < anm.numBones; boneIndex++) {
+    const translations = transformBuffers[boneIndex].translations;
+    const rotations = transformBuffers[boneIndex].rotations;
+    if (translations) {
+      tracks.push(
+        new VectorKeyframeTrack(
+          `sh1model.bones[${boneIndex}].position`,
+          timeBuffer,
+          translations,
+          InterpolateLinear
+        )
+      );
+    }
+    if (rotations) {
+      tracks.push(
+        new QuaternionKeyframeTrack(
+          `sh1model.bones[${boneIndex}].quaternion`,
+          timeBuffer,
+          rotations,
+          InterpolateLinear
+        )
+      );
+    }
   }
 
   return tracks;
+};
+
+// psx tim parsing
+
+const clut = (x: number) => (x / 31) * 255;
+
+import psx_frag from "./glsl/psx_frag.glsl?raw";
+import psx_vert from "./glsl/psx_vert.glsl?raw";
+import { clientState } from "./objects/MuseumState";
+
+export const texture = (psxTim: PsxTim, bpp = 4) => {
+  if (bpp !== 4) {
+    throw new Error("BPP must be 4");
+  }
+
+  const clutInfo = psxTim.clut;
+  const clutWidth = clutInfo.width;
+  const clutHeight = clutInfo.height;
+  const clutTexture = new Uint8Array(4 * clutWidth * clutHeight);
+
+  let clutIndex = 0;
+  for (let i = 0; i < psxTim.clut.body.length; i += 2) {
+    const clut16 = psxTim.clut.body[i] | (psxTim.clut.body[i + 1] << 8);
+    const r = clut(clut16 & 0x1f);
+    const g = clut((clut16 >> 5) & 0x1f);
+    const b = clut((clut16 >> 10) & 0x1f);
+    clutTexture[clutIndex] = r;
+    clutTexture[clutIndex + 1] = g;
+    clutTexture[clutIndex + 2] = b;
+    clutTexture[clutIndex + 3] = 255;
+
+    clutIndex += 4;
+  }
+
+  const imageWidth = psxTim.img.width * 4;
+  const imageHeight = psxTim.img.height;
+  const imageTexture = new Uint8Array(imageWidth * imageHeight);
+
+  let pixelIndex = 0;
+  for (let i = 0; i < psxTim.img.body.length; i += 2) {
+    const clut4 = psxTim.img.body[i] | (psxTim.img.body[i + 1] << 8);
+    imageTexture[pixelIndex] = clut4 & 0xf;
+    imageTexture[pixelIndex + 1] = (clut4 >> 4) & 0xf;
+    imageTexture[pixelIndex + 2] = (clut4 >> 8) & 0xf;
+    imageTexture[pixelIndex + 3] = (clut4 >> 12) & 0xf;
+    pixelIndex += 4;
+  }
+
+  const viewer = clientState.getTextureViewer();
+  console.debug(viewer);
+  if (viewer) {
+    viewer.addDataTexture(imageTexture, imageWidth, imageHeight, {
+      grayscale: true,
+      interpolation: "nearest",
+    });
+    viewer.addDataTexture(clutTexture, clutWidth, clutHeight, {
+      grayscale: false,
+      interpolation: "nearest",
+    });
+  }
+
+  const clutDataTexture = new DataTexture(clutTexture, clutWidth, clutHeight);
+  clutDataTexture.needsUpdate = true;
+
+  const imgDataTexture = new DataTexture(
+    imageTexture,
+    imageWidth,
+    imageHeight,
+    RedFormat
+  );
+  imgDataTexture.needsUpdate = true;
+
+  const mat = new RawShaderMaterial({
+    vertexShader: psx_vert,
+    fragmentShader: psx_frag,
+    uniforms: {
+      tClutTexture: { value: clutDataTexture },
+      imgTexture: { value: imgDataTexture },
+    },
+    glslVersion: GLSL3,
+    transparent: true,
+  });
+
+  mat.uniformsNeedUpdate = true;
+
+  return mat;
 };
 
 // 🗂️ ------- file structure associations ------- 🗂️
@@ -329,7 +460,7 @@ export const ilmToAnmArray = [
   ["SIBYL", "SBL2"],
   ["HERO", "HR_E01"],
   ["SIBYL", "SBL_LAST"],
-  ["SNK", "SPD"],
+  // ["SNK", "SPD"],
 ] as const;
 type SpecialIlmName = (typeof ilmToAnmArray)[number][0];
 type SpecialAnmName = (typeof ilmToAnmArray)[number][1];
@@ -359,3 +490,67 @@ export const anmToIlmAssoc = (anmName: string) => {
 
   return name + ".ILM";
 };
+
+export const ilmToTextureAssoc = (name: string) => {
+  switch (name) {
+    case "WRM":
+      return "WORM";
+    case "BIRD":
+      return "BD2";
+    case "MTH":
+      return "MOTH";
+    case "MAN":
+      return "HERO";
+  }
+  return name;
+};
+
+export const ilmFiles = [
+  "AR",
+  "BAR",
+  "BD2",
+  "BFLU",
+  "BIG",
+  "BIRD",
+  "BLISA",
+  "BOS",
+  "BTFY",
+  "CAT",
+  "CKN",
+  "CLD1",
+  "CLD2",
+  "CLD3",
+  "CLD4",
+  "COC",
+  "DARIA",
+  "DEAD",
+  "DG2",
+  "DOB",
+  "DOC",
+  "DOG",
+  "EI",
+  "FAT",
+  "FRG",
+  "HERO",
+  "ICU",
+  "JACK",
+  "KAU",
+  "LISA",
+  "LITL",
+  "MAN",
+  "MAR",
+  "MKY",
+  "MSB",
+  "MTH",
+  "OST",
+  "PRS",
+  "PRSD",
+  "ROD",
+  "SIBYL",
+  "SLT",
+  "SNK",
+  "SRL",
+  "TAR",
+  "TDRA",
+  "WRM",
+] as const;

--- a/src/tests/sh1.spec.ts
+++ b/src/tests/sh1.spec.ts
@@ -12,18 +12,6 @@ import PsxTim from "../kaitai/PsxTim";
 const ILM_PATH = path.join(__dirname, "../../public/sh1/CHARA");
 const ANM_PATH = path.join(__dirname, "../../public/sh1/ANIM");
 
-// just guesses
-
-// TODO: parse the partial animations
-// @ts-ignore
-const parsePartialAnm = (baseAnm: Sh1anm, partialStream: KaitaiStream) => {
-  baseAnm.magic = 0;
-  baseAnm._m_frameData = undefined;
-  baseAnm._io = partialStream;
-  baseAnm.frameData; // access frame data to call setter
-  return baseAnm;
-};
-
 const getFileList = (dir: string, ext: string) => {
   return fs
     .readdirSync(dir)
@@ -52,8 +40,7 @@ describe("ilm + sh1anm", () => {
       expect(anm).toBeDefined();
     });
 
-    const imageFile =
-      ilmToTextureAssoc(ilmFile.replace(".ILM", ""), true) + ".TIM";
+    const imageFile = ilmToTextureAssoc(ilmFile.replace(".ILM", "")) + ".TIM";
     test(`${imageFile}`, async () => {
       let imageBytes;
       try {

--- a/src/tests/sh1.spec.ts
+++ b/src/tests/sh1.spec.ts
@@ -5,8 +5,9 @@ import { fetchRawBytes } from "../load";
 import Ilm from "../kaitai/Ilm";
 import Sh1anm from "../kaitai/Sh1anm";
 import KaitaiStream from "../kaitai/runtime/KaitaiStream";
-import { ilmToAnmAssoc, anmToIlmAssoc } from "../sh1";
+import { ilmToAnmAssoc, anmToIlmAssoc, ilmToTextureAssoc } from "../sh1";
 import logger from "../objects/Logger";
+import PsxTim from "../kaitai/PsxTim";
 
 const ILM_PATH = path.join(__dirname, "../../public/sh1/CHARA");
 const ANM_PATH = path.join(__dirname, "../../public/sh1/ANIM");
@@ -49,6 +50,22 @@ describe("ilm + sh1anm", () => {
       const anmStream = new KaitaiStream(anmBytes);
       const anm = new Sh1anm(anmStream);
       expect(anm).toBeDefined();
+    });
+
+    const imageFile =
+      ilmToTextureAssoc(ilmFile.replace(".ILM", ""), true) + ".TIM";
+    test(`${imageFile}`, async () => {
+      let imageBytes;
+      try {
+        imageBytes = await fetchRawBytes(path.join(ILM_PATH, imageFile));
+      } catch (e) {
+        return;
+      }
+
+      const imageStream = new KaitaiStream(imageBytes);
+      const image = new PsxTim(imageStream);
+      expect(image).toBeDefined();
+      expect(image.bpp).toBe(0);
     });
   });
 


### PR DESCRIPTION
heavily wip but this expands the collection of sh1 models and attempts to make textures more realistic by imitating how the ps1 gpu works!

it will temporarily disable the "export to gltf" button, but i do plan to support this feature. the sh1 rendering will use custom shaders from now on, which aren't directly supported by three's gltf export feature