### PR TITLE
fix: compatibility issues for psx texture shader

### DIFF
--- a/src/glsl/psx_frag.glsl
+++ b/src/glsl/psx_frag.glsl
@@ -1,24 +1,31 @@
-precision mediump float;
-precision mediump int;
+precision highp float;
+precision highp int;
+precision highp sampler2D;
+precision highp usampler2D;
 
-in vec4 vUv;
+in vec2 vUv;
+flat in ivec2 vTexInfo;
+
 uniform vec3 ambientLightColor;
-uniform sampler2D tClutTexture;
-uniform sampler2D imgTexture;
+uniform sampler2D clutTexture;
+uniform usampler2D imgTexture;
+uniform vec2 imgSize;
 uniform float opacity;
 uniform float alphaTest;
 
 layout(location = 0) out highp vec4 pc_fragColor;
 
 void main() {
-    vec2 img_xy = vec2(vUv.x, vUv.y);
-    float palette_idx = texture(imgTexture, img_xy).r;
+    int clutRow = vTexInfo.y;
 
-    vec2 clut_xy = vec2(palette_idx * 255.0 / 16.0, vUv.w);
-    vec4 color = texture(tClutTexture, clut_xy);
+    ivec2 imgXy = ivec2(vUv.xy * imgSize);
+    uint paletteIndex = texelFetch(imgTexture, imgXy, 0).r;
+
+    ivec2 clutXy = ivec2(paletteIndex, clutRow);
+    vec4 color = texelFetch(clutTexture, clutXy, 0);
 
     float alpha = opacity * color.a;
-    if(alpha <= alphaTest) {
+    if (alpha <= alphaTest) {
         discard;
     }
 

--- a/src/glsl/psx_vert.glsl
+++ b/src/glsl/psx_vert.glsl
@@ -1,8 +1,9 @@
-precision mediump float;
-precision mediump int;
+precision highp float;
+precision highp int;
 
 in vec3 position;
-in vec4 uv;
+in vec2 uv;
+in ivec2 texInfo;
 in vec4 skinIndex;
 in vec4 skinWeight;
 
@@ -12,7 +13,8 @@ uniform mat4 bindMatrix;
 uniform mat4 bindMatrixInverse;
 uniform highp sampler2D boneTexture;
 
-out vec4 vUv;
+out vec2 vUv;
+flat out ivec2 vTexInfo;
 
 mat4 getBoneMatrix(const in float i) {
     int size = textureSize(boneTexture, 0).x;
@@ -28,6 +30,7 @@ mat4 getBoneMatrix(const in float i) {
 
 void main() {
     vUv = uv;
+    vTexInfo = texInfo;
 
     vec3 transformed = vec3(position);
     mat4 boneMatX = getBoneMatrix(skinIndex.x);


### PR DESCRIPTION
attempts to address #46!

- separates texture info, including CLUT row, into a separate `flat` uniform. i lazily packed it into the uv (image texture coord), but that means it can get interpolated which we don't want
- use a `usampler2d` for image textures, and `texelFetch` instead of `texture` because all the data is integer

for some reason neither of these issues mattered on my device/gpu, but they do seem to make a difference on other machines. hopefully this resolves the issue across the board...

 